### PR TITLE
Default export/import for react-playable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
-export { ReactPlayable, ReactPlayableProps } from './components/ReactPlayable';
+import { ReactPlayable, ReactPlayableProps } from './components/ReactPlayable';
+
+export { ReactPlayable, ReactPlayableProps };
+export default ReactPlayable;
+


### PR DESCRIPTION
To be able import `ReactPlayable` with next statement
```
import ReactPlayable from 'react-playable';
```
We need to add default module export.