### PR TITLE
fix: import playable from dist to avoid auto-resulution to package.js…

### DIFF
--- a/src/components/ReactPlayable/ReactPlayable.tsx
+++ b/src/components/ReactPlayable/ReactPlayable.tsx
@@ -25,7 +25,7 @@ import {
   MEDIA_STREAM_TYPES,
   PlayableMediaSource,
   PRELOAD_TYPES,
-} from 'playable';
+} from 'playable/dist/src/index';
 
 const PlayableSource = exact({
   url: string,


### PR DESCRIPTION
…on:main field

![Screen Shot 2019-06-12 at 2 12 01 AM](https://user-images.githubusercontent.com/5727408/59313471-d4e31100-8cb9-11e9-8f5e-330fcc08006e.jpg)

This has already happened twice: 
https://github.com/wix-private/video-player-react/commit/7b950d9adae48f5f7f82626fe0ece0ec542abe1d

What is the reason behind playable.bundle.js set as main in playable's package.json?